### PR TITLE
changed delay to delayMicroseconds in order to optimize delay times. …

### DIFF
--- a/src/DDBooster.cpp
+++ b/src/DDBooster.cpp
@@ -7,8 +7,8 @@
 
 #include "DDBooster.h"
 
-#define BOOSTER_CMD_DELAY    2
-#define BOOSTER_LED_DELAY    6
+#define BOOSTER_CMD_DELAY    500
+#define BOOSTER_LED_DELAY    30
 
 #define BOOSTER_SETRGB       0xA1
 #define BOOSTER_SETRGBW      0xA2
@@ -266,7 +266,7 @@ void DDBooster::show() {
     uint8_t cmd[1];
     cmd[0] = BOOSTER_SHOW;
     sendData(cmd, sizeof (cmd));
-    delay(BOOSTER_LED_DELAY);
+    delayMicroseconds(BOOSTER_LED_DELAY * (_lastIndex + 1));
 }
 
 void DDBooster::sendData(uint8_t *buffer, uint8_t length) {
@@ -275,5 +275,5 @@ void DDBooster::sendData(uint8_t *buffer, uint8_t length) {
         SPI.transfer(buffer[i]);
     }
     digitalWrite(_csPin, HIGH);
-    delay(BOOSTER_CMD_DELAY);
+    delayMicroseconds(BOOSTER_CMD_DELAY);
 }


### PR DESCRIPTION
…CMD_DELAY works fine with 500us due to slow arduino digitalWrite speed. LED_DELAY is now calculated from the number of leds and a delay time of 30us per led as mentioned in the data sheet of digi dot booster.
